### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This Model Context Protocol (MCP) server provides a programmatic interface to the IACR Cryptology ePrint Archive, enabling efficient retrieval of cryptographic research papers.
 
+<a href="https://glama.ai/mcp/servers/e2oh3a96de"><img width="380" height="200" src="https://glama.ai/mcp/servers/e2oh3a96de/badge" alt="IACR Server MCP server" /></a>
+
 ## Features
 
 - 🔍 Search cryptographic papers


### PR DESCRIPTION
This PR adds a badge for the [IACR MCP Server](https://glama.ai/mcp/servers/e2oh3a96de) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/e2oh3a96de"><img width="380" height="200" src="https://glama.ai/mcp/servers/e2oh3a96de/badge" alt="IACR Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.